### PR TITLE
fix: GetSeedNode `id` and `uri` GraphQL params are required. (#1463)

### DIFF
--- a/.changeset/fifty-ants-dress.md
+++ b/.changeset/fifty-ants-dress.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Fixed a bug in the seed query when persisted queries are enabled. Thanks @justlevine!

--- a/internal/faustjs.org/docs/faustwp/seed-query.mdx
+++ b/internal/faustjs.org/docs/faustwp/seed-query.mdx
@@ -43,8 +43,8 @@ export interface SeedNode {
 
 export const SEED_QUERY = gql`
   query GetSeedNode(
-    $id: ID = 0
-    $uri: String = ""
+    $id: ID! = 0
+    $uri: String! = ""
     $asPreview: Boolean = false
   ) {
     ... on RootQuery @skip(if: $asPreview) {

--- a/packages/faustwp-core/src/queries/seedQuery.ts
+++ b/packages/faustwp-core/src/queries/seedQuery.ts
@@ -26,8 +26,8 @@ export interface SeedNode {
 
 export const SEED_QUERY = gql`
   query GetSeedNode(
-    $id: ID = 0
-    $uri: String = ""
+    $id: ID! = 0
+    $uri: String! = ""
     $asPreview: Boolean = false
   ) {
     ... on RootQuery @skip(if: $asPreview) {


### PR DESCRIPTION
* fix: GetSeedNode `$id` is required

* fix: URI is also required in GetSeedNode

* Update seed-query.mdx

* Add changeset

* Grammar

---------

## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
